### PR TITLE
Upgrade Jacoco Maven plugin version to 0.7.3.201502191951

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.6.3.201306030806</version>
+                        <version>0.7.3.201502191951</version>
                         <executions>
                             <execution>
                                 <id>prepare-jacoco</id>


### PR DESCRIPTION
0.6.3 version has compatibility issues with Java 8.