### PR TITLE
REPO-4243/ACE-5955: Rest-Api Workflow processes and task tests are failing on ACS 6.0.1.1

### DIFF
--- a/src/main/java/org/alfresco/dataprep/AlfrescoHttpClient.java
+++ b/src/main/java/org/alfresco/dataprep/AlfrescoHttpClient.java
@@ -69,13 +69,17 @@ public class AlfrescoHttpClient
     private int sharePort;
     private String apiUrl;
     private String alfrescoUrl;
+    private String adminUser;
+    private String adminPassword;
 
-    public AlfrescoHttpClient(final String scheme, final String host, final int port, final int sharePort)
+    public AlfrescoHttpClient(final String scheme, final String host, final int port, final int sharePort, final String adminUser, final String adminPassword)
     {
         this.scheme = scheme;
         this.host = host;
         this.port = port;
         this.sharePort = sharePort;
+        this.adminUser = adminUser;
+        this.adminPassword = adminPassword;
         apiUrl = String.format("%s://%s:%d/%s", scheme, host, port,ALFRESCO_API_PATH);
         client = HttpClientBuilder.create().build();
     }
@@ -222,7 +226,22 @@ public class AlfrescoHttpClient
         }
         return execute(request);
     }
-    
+
+    /**
+     * Execute HttpClient request as admin user without releasing the connection
+     * @param request to send 
+     * @return {@link HttpResponse} response
+     */
+    public HttpResponse executeAsAdmin(HttpRequestBase request)
+    {
+        if(!StringUtils.isEmpty(this.adminUser) || !StringUtils.isEmpty(this.adminPassword))
+        {
+            client = getHttpClientWithBasicAuth(this.adminUser, this.adminPassword);
+            setBasicAuthorization(this.adminUser, this.adminPassword, request);
+        }
+        return execute(request);
+    }
+
     /**
      * Execute HttpClient request.
      * @param userName String user name 
@@ -292,6 +311,26 @@ public class AlfrescoHttpClient
         provider.setCredentials(AuthScope.ANY, credentials);
         CloseableHttpClient client = HttpClientBuilder.create().setDefaultCredentialsProvider(provider).build();
         return client;
+    }
+
+    public String getAdminUser()
+    {
+        return adminUser;
+    }
+
+    public void setAdminUser(String adminUser)
+    {
+        this.adminUser = adminUser;
+    }
+
+    public String getAdminPassword()
+    {
+        return adminPassword;
+    }
+
+    public void setAdminPassword(String adminPassword)
+    {
+        this.adminPassword = adminPassword;
     }
 
     private HttpRequestBase setBasicAuthorization(String userName, String password, HttpRequestBase request)

--- a/src/main/java/org/alfresco/dataprep/AlfrescoHttpClientFactory.java
+++ b/src/main/java/org/alfresco/dataprep/AlfrescoHttpClientFactory.java
@@ -28,7 +28,29 @@ public class AlfrescoHttpClientFactory implements FactoryBean<AlfrescoHttpClient
     private String scheme;
     private int port;
     private int sharePort;
+    private String adminUser;
+    private String adminPassword;
     
+    public String getAdminUser()
+    {
+        return adminUser;
+    }
+
+    public void setAdminUser(String adminUser)
+    {
+        this.adminUser = adminUser;
+    }
+
+    public String getAdminPassword()
+    {
+        return adminPassword;
+    }
+
+    public void setAdminPassword(String adminPassword)
+    {
+        this.adminPassword = adminPassword;
+    }
+
     public int getSharePort()
     {
         return sharePort;
@@ -42,7 +64,7 @@ public class AlfrescoHttpClientFactory implements FactoryBean<AlfrescoHttpClient
     @Scope("prototype")
     public AlfrescoHttpClient getObject()
     {
-        return new AlfrescoHttpClient(scheme, host, port, sharePort);
+        return new AlfrescoHttpClient(scheme, host, port, sharePort, adminUser, adminPassword);
     }
 
     public Class<?> getObjectType()

--- a/src/main/java/org/alfresco/dataprep/CMISUtil.java
+++ b/src/main/java/org/alfresco/dataprep/CMISUtil.java
@@ -160,7 +160,7 @@ public class CMISUtil
         }
     }
     
-    @Autowired protected  AlfrescoHttpClientFactory alfrescoHttpClientFactory;
+    @Autowired protected AlfrescoHttpClientFactory alfrescoHttpClientFactory;
     Map<String, String> contents = new HashMap<String,String>();
 
     /**

--- a/src/main/resources/dataprep-context.xml
+++ b/src/main/resources/dataprep-context.xml
@@ -17,5 +17,7 @@
         <property name="port" value="${alfresco.port}" />
         <property name="scheme" value="${alfresco.scheme}" />
         <property name="sharePort" value="${share.port}" />
+        <property name="adminUser" value="${admin.user}" />
+        <property name="adminPassword" value="${admin.password}" />
     </bean>
 </beans>

--- a/src/main/resources/dataprep.properties
+++ b/src/main/resources/dataprep.properties
@@ -1,7 +1,7 @@
 # Properties for Public API
 alfresco.scheme=http
 alfresco.server=localhost
-alfresco.port=8082
+alfresco.port=8080
 share.port=8080
 
 # credentials

--- a/src/main/resources/dataprep.properties
+++ b/src/main/resources/dataprep.properties
@@ -1,5 +1,9 @@
 # Properties for Public API
 alfresco.scheme=http
 alfresco.server=localhost
-alfresco.port=8080
+alfresco.port=8082
 share.port=8080
+
+# credentials
+admin.user=admin
+admin.password=admin

--- a/src/test/java/org/alfresco/test/util/AlfrescoHttpClientTest.java
+++ b/src/test/java/org/alfresco/test/util/AlfrescoHttpClientTest.java
@@ -34,7 +34,7 @@ public class AlfrescoHttpClientTest
     @BeforeMethod
     public void init()
     {
-        client = new AlfrescoHttpClient("http","localhost",8080, 8080);
+        client = new AlfrescoHttpClient("http","localhost",8080, 8080, "admin", "admin");
     }
     @AfterMethod
     public void tearDown() throws IOException


### PR DESCRIPTION
- get process definition ids from the system instead of using hard-coded ids